### PR TITLE
Reject request for wrong audience in IMC event_receiver

### DIFF
--- a/pkg/channel/fanout/fanout_event_handler.go
+++ b/pkg/channel/fanout/fanout_event_handler.go
@@ -24,8 +24,6 @@ package fanout
 import (
 	"context"
 	"errors"
-	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
-	"knative.dev/eventing/pkg/auth"
 	nethttp "net/http"
 	"sync"
 	"time"
@@ -85,8 +83,6 @@ type FanoutEventHandler struct {
 
 	eventDispatcher *kncloudevents.Dispatcher
 
-	TokenVerifier *auth.OIDCTokenVerifier
-
 	// TODO: Plumb context through the receiver and dispatcher and use that to store the timeout,
 	// rather than a member variable.
 	timeout time.Duration
@@ -95,7 +91,6 @@ type FanoutEventHandler struct {
 	logger             *zap.Logger
 	eventTypeHandler   *eventtype.EventTypeAutoHandler
 	channelAddressable *duckv1.KReference
-	imc                *v1.InMemoryChannel
 	channelUID         *types.UID
 }
 
@@ -105,11 +100,9 @@ func NewFanoutEventHandler(
 	config Config,
 	reporter channel.StatsReporter,
 	eventTypeHandler *eventtype.EventTypeAutoHandler,
-	channelAddressable *duckv1.KReference,
-	imc *v1.InMemoryChannel,
+	channelRef *duckv1.KReference,
 	channelUID *types.UID,
 	eventDispatcher *kncloudevents.Dispatcher,
-	TokenVerifier *auth.OIDCTokenVerifier,
 	receiverOpts ...channel.EventReceiverOptions,
 
 ) (*FanoutEventHandler, error) {
@@ -119,16 +112,15 @@ func NewFanoutEventHandler(
 		reporter:           reporter,
 		asyncHandler:       config.AsyncHandler,
 		eventTypeHandler:   eventTypeHandler,
-		channelAddressable: channelAddressable,
+		channelAddressable: channelRef,
 		channelUID:         channelUID,
 		eventDispatcher:    eventDispatcher,
-		TokenVerifier:      TokenVerifier,
 	}
 	handler.subscriptions = make([]Subscription, len(config.Subscriptions))
 	copy(handler.subscriptions, config.Subscriptions)
 	// The receiver function needs to point back at the handler itself, so set it up after
 	// initialization.
-	receiver, err := channel.NewEventReceiver(createEventReceiverFunction(handler), logger, reporter, handler, receiverOpts...)
+	receiver, err := channel.NewEventReceiver(createEventReceiverFunction(handler), logger, reporter, receiverOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -170,15 +162,6 @@ func SubscriberSpecToFanoutConfig(sub eventingduckv1.SubscriberSpec) (*Subscript
 	}
 
 	return &Subscription{Subscriber: destination, Reply: reply, DeadLetter: deadLetter, RetryConfig: retryConfig}, nil
-}
-
-func (f *FanoutEventHandler) GetChannelObject() *v1.InMemoryChannel {
-	// convert the channel addressable to a channel object
-	channelObject := &v1.InMemoryChannel{}
-	channelObject.SetName(f.channelAddressable.Name)
-	channelObject.SetNamespace(f.channelAddressable.Namespace)
-	channelObject.SetUID(*f.channelUID)
-	return channelObject
 }
 
 func (f *FanoutEventHandler) SetSubscriptions(ctx context.Context, subs []Subscription) {

--- a/pkg/channel/fanout/fanout_event_handler_test.go
+++ b/pkg/channel/fanout/fanout_event_handler_test.go
@@ -390,9 +390,7 @@ func testFanoutEventHandler(t *testing.T, async bool, receiverFunc channel.Event
 		nil,
 		nil,
 		nil,
-		nil,
 		dispatcher,
-		nil,
 		recvOptionFunc,
 	)
 	<-calledChan

--- a/pkg/channel/multichannelfanout/multi_channel_fanout_event_handler.go
+++ b/pkg/channel/multichannelfanout/multi_channel_fanout_event_handler.go
@@ -74,7 +74,7 @@ func NewEventHandlerWithConfig(_ context.Context, logger *zap.Logger, conf Confi
 			if key == "" {
 				continue
 			}
-			handler, err := fanout.NewFanoutEventHandler(logger, cc.FanoutConfig, reporter, cc.EventTypeHandler, cc.ChannelAddressable, nil, cc.ChannelUID, eventDispatcher, nil, recvOptions...)
+			handler, err := fanout.NewFanoutEventHandler(logger, cc.FanoutConfig, reporter, cc.EventTypeHandler, cc.ChannelAddressable, cc.ChannelUID, eventDispatcher, recvOptions...)
 			if err != nil {
 				logger.Error("Failed creating new fanout handler.", zap.Error(err))
 				return nil, err

--- a/pkg/channel/multichannelfanout/multi_channel_fanout_event_handler_test.go
+++ b/pkg/channel/multichannelfanout/multi_channel_fanout_event_handler_test.go
@@ -123,7 +123,7 @@ func TestNewEventHandler(t *testing.T) {
 	if h != nil {
 		t.Errorf("Found handler for %q but not expected", handlerName)
 	}
-	f, err := fanout.NewFanoutEventHandler(logger, fanout.Config{}, reporter, nil, nil, nil, nil, dispatcher, nil, nil)
+	f, err := fanout.NewFanoutEventHandler(logger, fanout.Config{}, reporter, nil, nil, nil, dispatcher)
 	if err != nil {
 		t.Error("Failed to create FanoutMessagHandler: ", err)
 	}

--- a/pkg/reconciler/inmemorychannel/dispatcher/controller.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller.go
@@ -128,6 +128,7 @@ func NewController(
 		eventingClient:           eventingclient.Get(ctx).EventingV1beta2(),
 		eventTypeLister:          eventtypeinformer.Get(ctx).Lister(),
 		eventDispatcher:          kncloudevents.NewDispatcher(oidcTokenProvider),
+		tokenVerifier:            auth.NewOIDCTokenVerifier(ctx),
 	}
 
 	impl := inmemorychannelreconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
@@ -37,6 +37,7 @@ import (
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/apis/feature"
 	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	"knative.dev/eventing/pkg/auth"
 	"knative.dev/eventing/pkg/channel"
 	"knative.dev/eventing/pkg/channel/fanout"
 	"knative.dev/eventing/pkg/channel/multichannelfanout"
@@ -57,6 +58,7 @@ type Reconciler struct {
 	eventingClient           eventingv1beta2.EventingV1beta2Interface
 	featureStore             *feature.Store
 	eventDispatcher          *kncloudevents.Dispatcher
+	tokenVerifier            *auth.OIDCTokenVerifier
 }
 
 // Check the interfaces Reconciler should implement
@@ -111,6 +113,10 @@ func (r *Reconciler) reconcile(ctx context.Context, imc *v1.InMemoryChannel) rec
 		UID = &imc.UID
 	}
 
+	wc := func(ctx context.Context) context.Context {
+		return r.featureStore.ToContext(ctx)
+	}
+
 	// First grab the host based MultiChannelFanoutMessage httpHandler
 	httpHandler := r.multiChannelEventHandler.GetChannelHandler(config.HostName)
 	if httpHandler == nil {
@@ -121,10 +127,10 @@ func (r *Reconciler) reconcile(ctx context.Context, imc *v1.InMemoryChannel) rec
 			r.reporter,
 			eventTypeAutoHandler,
 			channelRef,
-			imc,
 			UID,
 			r.eventDispatcher,
-			nil,
+			channel.OIDCTokenVerification(r.tokenVerifier, audience(imc)),
+			channel.ReceiverWithContextFunc(wc),
 		)
 		if err != nil {
 			logging.FromContext(ctx).Error("Failed to create a new fanout.EventHandler", err)
@@ -152,11 +158,11 @@ func (r *Reconciler) reconcile(ctx context.Context, imc *v1.InMemoryChannel) rec
 			r.reporter,
 			eventTypeAutoHandler,
 			channelRef,
-			imc,
 			UID,
 			r.eventDispatcher,
-			nil,
 			channel.ResolveChannelFromPath(channel.ParseChannelFromPath),
+			channel.OIDCTokenVerification(r.tokenVerifier, audience(imc)),
+			channel.ReceiverWithContextFunc(wc),
 		)
 		if err != nil {
 			logging.FromContext(ctx).Error("Failed to create a new fanout.EventHandler", err)
@@ -290,4 +296,8 @@ func toKReference(imc *v1.InMemoryChannel) *duckv1.KReference {
 		Name:       imc.Name,
 		Address:    imc.Status.Address.Name,
 	}
+}
+
+func audience(imc *v1.InMemoryChannel) string {
+	return auth.GetAudience(v1.SchemeGroupVersion.WithKind("InMemoryChannel"), imc.ObjectMeta)
 }

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
@@ -502,7 +502,7 @@ func TestReconciler_ReconcileKind(t *testing.T) {
 		dispatcher := kncloudevents.NewDispatcher(oidcTokenProvider)
 		// Just run the tests once with no existing handler (creates the handler) and once
 		// with an existing, so we exercise both paths at once.
-		fh, err := fanout.NewFanoutEventHandler(nil, fanout.Config{}, nil, nil, nil, nil, nil, dispatcher, nil)
+		fh, err := fanout.NewFanoutEventHandler(nil, fanout.Config{}, nil, nil, nil, nil, dispatcher)
 		if err != nil {
 			t.Error(err)
 		}
@@ -551,7 +551,7 @@ func TestReconciler_InvalidInputs(t *testing.T) {
 
 		oidcTokenProvider := auth.NewOIDCTokenProvider(ctx)
 		dispatcher := kncloudevents.NewDispatcher(oidcTokenProvider)
-		fh, err := fanout.NewFanoutEventHandler(nil, fanout.Config{}, nil, nil, nil, nil, nil, dispatcher, nil)
+		fh, err := fanout.NewFanoutEventHandler(nil, fanout.Config{}, nil, nil, nil, nil, dispatcher)
 		if err != nil {
 			t.Error(err)
 		}
@@ -585,7 +585,7 @@ func TestReconciler_Deletion(t *testing.T) {
 
 		oidcTokenProvider := auth.NewOIDCTokenProvider(ctx)
 		dispatcher := kncloudevents.NewDispatcher(oidcTokenProvider)
-		fh, err := fanout.NewFanoutEventHandler(nil, fanout.Config{}, nil, nil, nil, nil, nil, dispatcher, nil)
+		fh, err := fanout.NewFanoutEventHandler(nil, fanout.Config{}, nil, nil, nil, nil, dispatcher)
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
Adds support to reject request with the wrong audience to the IMC event_receiver.

I have a e2e test available in https://github.com/creydr/knative-eventing/commit/1f8db908d8b5fa6c1430756bb7ba60d3b1ed7f3a too, but you need to rebase your branch before (can be done afterwards)